### PR TITLE
fix:some apps not packaged error

### DIFF
--- a/repo/packages/c/cpp/scripts/deploy.lua
+++ b/repo/packages/c/cpp/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/c/cpp/xmake.lua
+++ b/repo/packages/c/cpp/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "cpp", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/h/hello/scripts/deploy.lua
+++ b/repo/packages/h/hello/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/h/hello/xmake.lua
+++ b/repo/packages/h/hello/xmake.lua
@@ -30,11 +30,29 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "hello", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
 
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
+
+        import("package.tools.xmake").install(package)
+        end
+
     end)
 
-    
 end

--- a/repo/packages/p/player/scripts/deploy.lua
+++ b/repo/packages/p/player/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/p/player/xmake.lua
+++ b/repo/packages/p/player/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "player", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/s/shm_ping/scripts/deploy.lua
+++ b/repo/packages/s/shm_ping/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/s/shm_ping/xmake.lua
+++ b/repo/packages/s/shm_ping/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "shm_ping", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/s/shm_pong/scripts/deploy.lua
+++ b/repo/packages/s/shm_pong/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/s/shm_pong/xmake.lua
+++ b/repo/packages/s/shm_pong/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "shm_pong", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/s/smart-fetch/scripts/deploy.lua
+++ b/repo/packages/s/smart-fetch/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/s/smart-fetch/xmake.lua
+++ b/repo/packages/s/smart-fetch/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "smart-fetch", "*")
         local bakdir = path.join(os.curdir(),"..","..")
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/u/umailbox/scripts/deploy.lua
+++ b/repo/packages/u/umailbox/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/u/umailbox/xmake.lua
+++ b/repo/packages/u/umailbox/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "umailbox", "*")
         local bakdir = path.join(os.curdir(),"..","..")
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/w/webclient/scripts/deploy.lua
+++ b/repo/packages/w/webclient/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/w/webclient/xmake.lua
+++ b/repo/packages/w/webclient/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "webclient", "*")
         local bakdir = path.join(os.curdir(),"..","..")
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+        end
     end)
 
 end

--- a/repo/packages/w/webserver/scripts/deploy.lua
+++ b/repo/packages/w/webserver/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/w/webserver/xmake.lua
+++ b/repo/packages/w/webserver/xmake.lua
@@ -30,12 +30,28 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "webserver", "*")
         local bakdir = path.join(os.curdir(),"..","..")
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
-        
+
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+    end
     end)
 
 end

--- a/repo/packages/z/zlib_app/scripts/deploy.lua
+++ b/repo/packages/z/zlib_app/scripts/deploy.lua
@@ -1,0 +1,46 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- You may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2023-2023 RT-Thread Development Team
+--
+-- @author      xqyjlj
+-- @file        deploy.lua
+--
+-- Change Logs:
+-- Date           Author       Notes
+-- ------------   ----------   -----------------------------------------------
+-- 2023-05-09     xqyjlj       initial version
+--
+import("rt.rt_utils")
+
+function main(rootfs, installdir, version)
+    for _, filepath in ipairs(os.files(path.join(installdir, "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "bin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "bin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "usr", "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "usr", "sbin", filename))
+    end
+
+    for _, filepath in ipairs(os.files(path.join(installdir, "sbin") .. "/*")) do
+        local filename = path.filename(filepath)
+        rt_utils.cp_with_symlink(filepath, path.join(rootfs, "sbin", filename))
+    end
+    
+end

--- a/repo/packages/z/zlib_app/xmake.lua
+++ b/repo/packages/z/zlib_app/xmake.lua
@@ -30,11 +30,27 @@ do
     on_install("cross@linux,windows", function(package)
         local sourcedir_files = path.join(os.curdir(),"apps", "zlib", "*")
         local bakdir = path.join(os.curdir())
+        local items_to_remove = {
+            "apps",
+            "assets",
+            "env.sh",
+            "README.md",
+            "repo",
+            "sdk",
+            "tools"
+        }
         print("sourcedir_files: " .. sourcedir_files)
         print("bakdir: " .. bakdir)
 
         os.cp(sourcedir_files, bakdir)
+        for _, item in ipairs(items_to_remove) do
+            local item_path = path.join(bakdir, item)
+            if os.exists(item_path) then
+                print("Removing: " .. item_path)
+                os.rm(item_path)
+        end
 
         import("package.tools.xmake").install(package)
+    end
     end)
 end


### PR DESCRIPTION
Added the “scripts” directory and the corresponding “deploy.lua” file, and modified the “xmake.lua” file for pulling and compiling the “apps” file to reduce the space consumption on the hard disk, and now there is a missing “apps” program in the “bin” directory of the “image” image after compiling and packaging.