### PR TITLE
Add manual build workflow and update README

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,54 @@
+name: Manual Build Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      machine:
+        description: 'Target Machine'
+        required: true
+        type: choice
+        options:
+          - qemuarm64
+          - qemuriscv64
+        default: 'qemuarm64'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gawk wget git diffstat unzip texinfo gcc build-essential \
+            chrpath socat cpio python3 python3-pip python3-pexpect \
+            xz-utils debianutils iputils-ping python3-git python3-jinja2 \
+            libegl1-mesa libsdl1.2-dev python3-subunit mesa-common-dev \
+            zstd liblz4-tool file locales
+          sudo locale-gen en_US.UTF-8
+
+      - name: Setup build environment
+        run: |
+          echo "Setting up build environment..."
+          source ./smart-env
+          echo "MACHINE=${{ github.event.inputs.machine }}" >> conf/local.conf
+
+      - name: Build RT-Smart
+        run: |
+          source ./smart-env
+          bitbake smart -c build_all
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.inputs.machine }}-build
+          path: |
+            build/${{ github.event.inputs.machine }}
+            build/tmp/work/*/smart/*/temp/log.*
+            build/tmp/log/cooker/* 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Smart Build
+
+[![Manual Build Status](https://github.com/RT-Thread/smart-build/actions/workflows/manual-build.yml/badge.svg)](https://github.com/RT-Thread/smart-build/actions/workflows/manual-build.yml)
+
 # smart-build
 build kernel/rootfs/bootloader for smart
 


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for manual builds, allowing users to select target machines.
- Updated README.md to include a badge for the manual build status, enhancing visibility of the build process.