### PR TITLE
Fix the rt-thread source folder issue and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,48 +10,44 @@ This README file contains information on the contents of the meta-smart layer.
 meta-smart 依赖 openembedded-core，作为openembedded的一个layer存在。
 
 以下是基于Ubuntu22.04的编译流程：
+
 ### 1. Host环境准备：
 ```bash
-$ sudo apt install build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping libacl1 liblz4-tool locales python3 python3-git python3-jinja2 python3-pexpect python3-pip python3-subunit socat texinfo unzip wget xz-utils zstd scons
+$ sudo apt install build-essential git curl vim python3 pip tmux bison flex file texinfo chrpath cpio diffstat gawk lz4 wget zstd qemu-system-arm
+$ sudo pip install requests scons kconfiglib tqdm
 ```
 
-### 2. 下载smart-build，切换到openembedded分支:
+### 2. 下载smart-build:
 ```bash
 $ git clone https://github.com/RT-Thread/smart-build.git
-$ git checkout -t origin/openembedded -b openembedded
 ```
 
-### 3. 进入smart-build目录，然后下载openembedded-core和bitbake：
+### 3. 进入smart-build目录，然后下载openembedded-core和bitbake仓库：
+
 ```bash
 $ cd smart-build/
 $ git clone git://git.openembedded.org/openembedded-core oe-core
 $ git clone git://git.openembedded.org/bitbake
 ```
 
-### 4. 切换到最新的master分支：
-```bash
-$ cd oe-core
-$ git branch -a
-$ git checkout -t origin/master -b my-master
-$ git pull
-$ cd ..
-```
-
-### 5. 设置bitbake编译环境：
+### 4. 设置bitbake编译环境：
 ```bash
 $ source smart-env  #会自动进入build目录
 ```
 或者指定自定义的构建目录名称：
 ```bash
-$ source smart-env custom-build  #会自动进入custom-build目录
+$ source smart-env build-custom  #会自动进入build-custom目录
 ```
 
 默认配置为：
 ```bash
-MACHINE ??= "qemuarm64"  #支持 qemuarm64 和 qemuriscv64
+MACHINE ??= "qemuarm64"
 ```
 
-### 6. 编译 smart-build 整个工程：
+也可以根据需要自行更改成 `qemuriscv64`
+
+### 5. 编译 smart-build 整个工程：
+
 ```bash
 $ bitbake smart -c build_all  #"smart"是配方名称, build_all表示同时完成toolchain安装、busybox编译及生成ext4.img，以及smart的kernel的编译。
 ```
@@ -61,6 +57,7 @@ $ bitbake smart -c build_all  #"smart"是配方名称, build_all表示同时完�
 最后编译smart kernel，并将生成的rtthread.bin拷贝到build/$MACHINE目录下。
 
 如果需要重新编译，可以执行清除处理：
+
 ```bash
 $ bitbake smart -c clean  #同时清除toolchain，busybox， smart的编译文件
 ```
@@ -70,84 +67,51 @@ $ bitbake smart -c clean  #同时清除toolchain，busybox， smart的编译文�
 $ cd build/qemuarm64
 $ ./run_qemuarm64.sh
 ```
+### 6. smart-build常用的操作指令：
 
-### 7. 单独安装 smart-gcc 工具链：
-```bash
-$ cd openembedded-core/build
-$ bitbake smart-gcc -c clean  #清除之前的编译
-$ rm -rf build/toolchains  #删除之前安装的toolchain
-$ bitbake smart-gcc -c install_toolchain  #"smart-gcc"是配方的名称, install_toolchain是自定义的Task。
-```
-该配方会先判断 build/toolchains 目录下是否存在系统默认的工具链，如果有的话不做任何操作；  
-如果没有，会从指定的链接下载工具链压缩包，然后解压到 build/toolchains 目录。
-
-### 8. 单独编译 busybox 生成ext4.img文件系统：
-```bash
-$ cd openembedded-core/build
-$ bitbake busybox -c clean  #清除之前的编译
-$ bitbake busybox -c build_rootfs
-```
-该配方会从指定地址下载busybox，然后解压、打patch、编译、以及生成ext4.img。
-最后将生成的ext4.img拷贝到build/$MACHINE目录下；
-
-编译Busybox之前会先判断Toolchain是否就绪，否则的话会先下载安装Toolchain。
-
-### 9. 单独编译 smart kernel：
-```bash
-$ cd openembedded-core/build
-$ bitbake smart -c clean  #清除之前的编译
-$ bitbake smart -c build_kernel
-```
-
-该配方会从指定地址下载rt-thread，然后进行编译。  
-生成的kernel地址如：tmp/work/cortexa57-poky-linux/smart/0.1/git/bsp/qemu-virt64-aarch64；  
-编译完成后会将生成的rtthread.bin拷贝到build/$MACHINE目录下；  
-
-编译smart之前会先判断Toolchain是否就绪，否则的话会先下载安装Toolchain。
-
-说明：由于bitbake不支持终端交互，所以暂无法通过bitbake方式直接进行menuconfig配置。  
-可以去源码目录（如 tmp/work/cortexa57-poky-linux/smart/0.1/git/bsp/qemu-virt64-aarch64 ）执行"scons --menuconfig"进行配置。
-然后将生成的.config文件去替换对应架构的默认配置文件，如recipes-kernel/rt-thread/qemuarm64_defconfig，下次再编译就会使用用户自己的默认配置了。
-
-### 10. smart-build常用的操作指令：
 1. 安装toolchain:
 ```bash
 $ bitbake smart-gcc -c install_toolchain
 ```
+
 2. 编译busybox并生成ext4.img (会先判断toolchain是否安装，否则会先安装)
 ```bash
 $ bitbake busybox -c build_rootfs
 ```
+
 3. 编译smart内核  (会先判断toolchain是否安装，否则会先安装)
 ```bash
 $ bitbake smart -c build_kernel 
 ```
+
 4. 编译busybox及smart内核
 ```bash
 $ bitbake smart -c build_all
 ```
+
 5. 同时清除toolchain, busybox, smart的编译数据
 ```bash
 $ bitbake smart -c clean/cleansstate/cleanall
 ```
+
 参数说明：
   * clean - 清除掉tmp下的编译目录；
   * cleansstate - 清除掉编译状态；
   * cleanall - 同时会清除掉下载的源文件；（慎用，否则又得下半天）
 
-### 11. Docker操作指南：
+### 7. Docker操作指南：
 本项目提供了开箱即用的Docker环境，位于 `tools/docker` 目录下。使用Docker可以避免环境配置问题，推荐使用此方式进行开发。
 
 1. 构建Docker镜像：
 ```bash
 $ cd tools/docker
-$ ./docker_build.sh
+$ sh ./docker_build.sh
 ```
 这将创建一个名为 `smart-build` 的Docker镜像，基于Ubuntu 24.04，已预装所有必要的开发工具和依赖。
 
 2. 运行Docker容器：
 ```bash
-$ ./docker_run.sh
+$ sh ./docker_run.sh
 ```
 
 该脚本会：

--- a/meta-smart/recipes-kernel/rt-thread/smart_0.1.bb
+++ b/meta-smart/recipes-kernel/rt-thread/smart_0.1.bb
@@ -25,6 +25,8 @@ python () {
     else:
         # 如果不存在本地目录，使用远程仓库
         set_preferred_source(d)
+        rtthread_src = os.path.join(d.getVar('WORKDIR', True), 'git')
+        d.setVar('S', rtthread_src)
         bb.plain("Local rt-thread not found, using remote repository")
 }
 
@@ -32,8 +34,6 @@ SRCREV_rtthread = "AUTOINC"
 SRCREV_lwext4 = "AUTOINC"
 
 SRCREV_FORMAT = "rtthread_lwext4"
-
-S ?= "${WORKDIR}/git"
 
 # 使用 LAYERDIR 来定位 meta-smart 层的位置
 LAYERDIR_smart = "${@os.path.dirname(os.path.dirname(os.path.dirname(d.getVar('FILE', True))))}"


### PR DESCRIPTION
- 修正当`smart-build/rt-thread`文件夹不存在时，`rt-thread`源代码路径的问题；
- 更新README.md，以反映在Ubuntu 22.04下需要安装的软件包。